### PR TITLE
Pre-Commit Black/Lint Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    -   id: black

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 
 # Install Java, Gradle, Git, Vim, and other dependencies
 RUN apt-get update && apt-get install -y \
+    bash-completion \
     default-jdk \
     default-jre \
     curl \
@@ -18,7 +19,6 @@ RUN apt-get update && apt-get install -y \
     && apt-get update && apt-get install -y elasticsearch \
     && rm -rf /var/lib/apt/lists/*
 
-
 # Change the terminal prompt color
 RUN echo 'PS1="\[\e[36m\]\u@\h:\w\$\[\e[m\] "' >> /root/.bashrc
 
@@ -28,6 +28,10 @@ RUN echo "set editing-mode vi" >> /etc/inputrc
 # Configure Vim history and undofile
 RUN echo "set history=1000" >> /etc/vim/vimrc \
     && echo "set undofile" >> /etc/vim/vimrc
+
+# Setup bash/git completions
+RUN echo "source /usr/share/bash-completion/bash_completion" >> /root/.bashrc \
+    && echo "source /usr/share/bash-completion/completions/git" >> /root/.bashrc \
 
 
 # Configure Elasticsearch

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     gradle \
     git \
     vim \
-    wget \ 
+    wget \
     gnupg \
     && wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor > /usr/share/keyrings/elasticsearch-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/7.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-7.x.list \
@@ -59,7 +59,10 @@ RUN pip install jupyter numpy scipy networkx pandas matplotlib black tqdm elasti
 # Configure Black formatter
 RUN echo "[tool.black]\nline-length = 120" > pyproject.toml
 
-# Make port available to the world outside this container 
+# Initialize pre-commit formatting
+RUN pre-commit install
+
+# Make port available to the world outside this container
 EXPOSE 9200
 EXPOSE 9300
 

--- a/discovery_markets.egg-info/SOURCES.txt
+++ b/discovery_markets.egg-info/SOURCES.txt
@@ -1,4 +1,3 @@
-README
 README.md
 setup.py
 discovery_markets.egg-info/PKG-INFO

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ networkx
 nltk
 numpy
 pandas
+pre-commit
 scikit-learn
 scipy
 tqdm


### PR DESCRIPTION
Sets up a pre-commit hook to reformat included files with `black`.

After this is merged, **make sure to rebuild the dev container to initialize the pre-commit hook.**

Also adds bash and git autocompletions to make life a little easier in the dev container shell.